### PR TITLE
20191203 패치 사항

### DIFF
--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -9,51 +9,64 @@
       </ul>
     </div>
   <% end %>
-  <div class="form-check form-check-inline">
-    <% types = ["지면용", "웹용"] %>
-    <% types.each do |type| %>
-      <%= f.label :story_type, type, class: "form-check-label" %>
-      <%= f.check_box :story_type, {multiple: true, class: "form-check-input"}, type, nil %>
-    <% end %>
-  </div>
-  <div class="form-row mb-4">
-    <div class="form-group col-auto">
-      <%= f.label "날짜", class: "form-label" %>
-      <%= f.date_select :date, {use_month_numbers: true}, {class: "custom-select bootstrap-date"} %>
+  <div class="row">
+    <div class="col-md-7">
+      <div class="form-check form-check-inline">
+        <% types = ["지면용", "웹용"] %>
+        <% types.each do |type| %>
+          <%= f.label :story_type, type, class: "form-check-label" %>
+          <%= f.check_box :story_type, {multiple: true, class: "form-check-input"}, type, nil %>
+        <% end %>
+      </div>
+      <div class="form-row mb-4">
+        <div class="form-group col-auto">
+          <%= f.label "날짜", class: "form-label" %>
+          <%= f.date_select :date, {use_month_numbers: true}, {class: "custom-select bootstrap-date"} %>
+        </div>
+        <div class="form-group float-right">
+          <%= f.button "저장", accesskey: "s", class: "btn btn-primary btn-lg", data: {disable_with: "<i class='fa fa-spinner fa-spin'></i> 처리중..."} %>
+        </div>
+      </div>
+      <div class="form-row">
+        <div class="form-group col-md-4">
+          <%= f.label '기획팀_기사분류', class: "col-form-label" %>
+          <%= f.select :category_code, [['사건/사고', 1601], ['법률',1602], ['교육',1603], ['노동', 1604], ['환경',1605], ['의료(보건복지)', 1606], ['시민사회', 1607], ['포토뉴스', 1608], ['피플', 1609]], { :include_blank => '-- 선택해주세요 --' }, required: true, class: "custom-select" %>
+        </div>
+        <div class="form-group col-md-4">
+          <%= f.label '가격', class: "col-form-label" %>
+          <%= f.select :price, [['무료', 0], ['500원', 20], ['1000원', 30]], {}, {class: "custom-select"} %>
+        </div>
+        <div class="form-group col-md-4">
+          <%= f.label '출고면_선택', class: "col-form-label" %>
+          <%= f.select :summitted_section, ['미정', '1면','정치','자치행정','국제통일','금융','산업','정책','기획','오피니언'], { :include_blank => '-- 선택해주세요 --' }, :required => true, class: "custom-select" %>
+        </div>
+      </div>
+      <div class="form-group">
+        <%= f.label :문패 %>
+        <%= f.text_field :subject_head, :size=>"40", class: "form-control", autocomplete: 'off' %>
+      </div>
+      <div class="form-group">
+        <%= f.label :제목 %>
+        <%= f.text_field :title, :size=>"40" , class: "form-control", autocomplete: 'off' %>
+      </div>
+      <div class="form-group">
+        <%= f.label :부제목 %>
+        <%= f.text_area :subtitle, cols: 40, rows: 4, class: "form-control batang", autocomplete: 'off' %>
+      </div>
+      <div class="from-group mb-5">
+        <%= f.label :본문 %>
+        <%= f.rich_text_area :content, autocomplete: 'off', style: "height: 500px; overflow-y:auto" %>
+      </div>
     </div>
-    <div class="form-group float-right">
-      <%= f.button "저장", accesskey: "s", class: "btn btn-primary btn-lg", data: {disable_with: "<i class='fa fa-spinner fa-spin'></i> 처리중..."} %>
+    <div class="col-md-5">
+      <div class="card bg-light mb-3">
+        <div class="card-header">기사번호 선택</div>
+        <div class="card-body">
+          <h5 class="card-title">Light card title</h5>
+          <p class="card-text">작성하신 기사를 현재 템플릿 페이지 중에서 넣어야 할 기사 번호를 선택해주세요.</p>
+        </div>
+      </div>
     </div>
-  </div>
-  <div class="form-row">
-    <div class="form-group col-md-4">
-      <%= f.label '기획팀_기사분류', class: "col-form-label" %>
-      <%= f.select :category_code, [['사건/사고', 1601], ['법률',1602], ['교육',1603], ['노동', 1604], ['환경',1605], ['의료(보건복지)', 1606], ['시민사회', 1607], ['포토뉴스', 1608], ['피플', 1609]], { :include_blank => '-- 선택해주세요 --' }, required: true, class: "custom-select" %>
-    </div>
-    <div class="form-group col-md-4">
-      <%= f.label '가격', class: "col-form-label" %>
-      <%= f.select :price, [['무료', 0], ['500원', 20], ['1000원', 30]], {}, {class: "custom-select"} %>
-    </div>
-    <div class="form-group col-md-4">
-      <%= f.label '출고면_선택', class: "col-form-label" %>
-      <%= f.select :summitted_section, ['미정', '1면','정치','자치행정','국제통일','금융','산업','정책','기획','오피니언'], { :include_blank => '-- 선택해주세요 --' }, :required => true, class: "custom-select" %>
-    </div>
-  </div>
-  <div class="form-group">
-    <%= f.label :문패 %>
-    <%= f.text_field :subject_head, :size=>"40", class: "form-control", autocomplete: 'off' %>
-  </div>
-  <div class="form-group">
-    <%= f.label :제목 %>
-    <%= f.text_field :title, :size=>"40" , class: "form-control", autocomplete: 'off' %>
-  </div>
-  <div class="form-group">
-    <%= f.label :부제목 %>
-    <%= f.text_area :subtitle, cols: 40, rows: 4, class: "form-control batang", autocomplete: 'off' %>
-  </div>
-  <div class="from-group mb-5">
-    <%= f.label :본문 %>
-    <%= f.rich_text_area :content, autocomplete: 'off', style: "height: 500px; overflow-y:auto" %>
   </div>
   <!-- 편집화면 하단에 자주쓰는 이전, 저장, 다운 버튼을 항상 보이게 설정 -->
   <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-bottom">

--- a/app/views/stories/new.html.erb
+++ b/app/views/stories/new.html.erb
@@ -1,7 +1,4 @@
-<div class="container mt-5">
-  <h3 class="text-center">기사작성</h3>
-  <%= render 'form', story: @story, user:@user%>
+<div class="container mt-3">
+  <h3 class="display-4 text-center" style="font-size: 40px;">기사작성</h3>
+  <%= render 'form', story: @story, user: @user %>
 </div>
-<!-- div align="center">
-    <%= link_to '이전으로', my_stories_path , method: :get, class: "btn btn-md btn-success"%>   
-</div-->

--- a/db/migrate/20191202235637_add_position_tag_stories.rb
+++ b/db/migrate/20191202235637_add_position_tag_stories.rb
@@ -1,0 +1,4 @@
+class AddPositionTagStories < ActiveRecord::Migration[5.2]
+  def change
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_02_223420) do
+ActiveRecord::Schema.define(version: 2019_12_02_235637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -372,6 +372,24 @@ ActiveRecord::Schema.define(version: 2019_12_02_223420) do
     t.index ["slug"], name: "index_issues_on_slug", unique: true
   end
 
+  create_table "layout_nodes", force: :cascade do |t|
+    t.string "direction"
+    t.integer "grid_x"
+    t.integer "grid_y"
+    t.integer "column"
+    t.integer "row"
+    t.string "profile"
+    t.string "node_kind"
+    t.string "tag"
+    t.boolean "selected"
+    t.text "actions"
+    t.text "layout"
+    t.text "layout_with_pillar_path"
+    t.integer "box_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "line_fragments", force: :cascade do |t|
     t.bigint "working_article_id"
     t.bigint "paragraph_id"
@@ -413,6 +431,25 @@ ActiveRecord::Schema.define(version: 2019_12_02_223420) do
     t.string "date"
     t.text "layout"
     t.integer "page_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "page_layouts", force: :cascade do |t|
+    t.float "doc_width"
+    t.float "doc_height"
+    t.string "ad_type"
+    t.string "page_type"
+    t.integer "column"
+    t.integer "row"
+    t.integer "pillar_count"
+    t.float "grid_width"
+    t.float "grid_height"
+    t.float "gutter"
+    t.float "margin"
+    t.text "layout"
+    t.text "layout_with_pillar_path"
+    t.integer "like"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -874,12 +911,12 @@ ActiveRecord::Schema.define(version: 2019_12_02_223420) do
     t.integer "height_in_lines"
     t.string "by_line"
     t.float "price"
+    t.string "category_name"
+    t.string "subcategory_code"
     t.integer "left_line", default: 0
     t.integer "top_line", default: 0
     t.integer "right_line", default: 0
     t.integer "bottom_line", default: 0
-    t.string "category_name"
-    t.string "subcategory_code"
     t.string "pillar_path"
     t.bigint "pillar_id"
     t.index ["article_id"], name: "index_working_articles_on_article_id"


### PR DESCRIPTION
1. stories/new.html.erb
    - 기사 작성의 레이아웃을 변경했습니다.
    - col-md-7와 col-md-5로 나뉘어서 왼쪽에는 기사 작성의 폼, 오른쪽에는 현재 템플릿 페이지에서 작성하고 있는 기사를 다음 번호 중에 추가해야 할 번호를 선택하면 됩니다.

2. migration 추가
    - stories 테이블에 position_tag 필드과 String 타입을 추가했습니다.